### PR TITLE
Use dev bootstrap instead of install instructions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,11 @@ Installation
 
 **Install via script - Ubuntu only**
 
-Best method for getting up and running quickly
+Best method for getting up and running quickly. This will install the requirements and activate a virtualenv.
 ***
 
 	
-	$ ./dev-bootstrap.sh
+	$ source dev-bootstrap.sh
 
 
 


### PR DESCRIPTION
@cgoldberg @jzoldak @clytwynec 

Here I remove most of the install instructions and replace it with:
- dev-bootstrap instructions
- list of requirements for anyone that doesn't use dev-bootstrap

Thoughts?
